### PR TITLE
Add Fix: Death from BGE

### DIFF
--- a/sim.cpp
+++ b/sim.cpp
@@ -454,6 +454,13 @@ void prepend_on_death(Field* fd,bool paybacked=false)
 {
     if (fd->killed_units.empty())
         return;
+    if (__builtin_expect(fd->fixes[Fix::death_from_bge], true)
+        && __builtin_expect(fd->current_phase == Field::bge_phase, false))
+    {
+        _DEBUG_MSG(2, "Death from BGE Fix (skip all death depended triggers)\n");
+        fd->killed_units.clear();
+        return;
+    }
     auto& assaults = fd->players[fd->killed_units[0]->m_player]->assaults;
     unsigned stacked_poison_value = 0;
     unsigned last_index = 99999;
@@ -3456,6 +3463,7 @@ Results<uint64_t> play(Field* fd,bool skip_init)
         }
 
         // Evaluate activation BGE skills
+        fd->current_phase = Field::bge_phase;
         for (const auto & bg_skill: fd->bg_skills[fd->tapi])
         {
             fd->prepare_action();

--- a/sim.h
+++ b/sim.h
@@ -318,12 +318,13 @@ public:
     enum phase
     {
         playcard_phase,
+        bge_phase,
         commander_phase,
         structures_phase,
         assaults_phase,
         end_phase,
     };
-    // the current phase of the turn: starts with playcard_phase, then commander_phase, structures_phase, and assaults_phase
+    // the current phase of the turn: starts with playcard_phase, then bge_phase, commander_phase, structures_phase, and assaults_phase
     phase current_phase;
     // the index of the card being evaluated in the current phase.
     // Meaningless in playcard_phase,

--- a/tyrant.h
+++ b/tyrant.h
@@ -16,7 +16,11 @@
 
 enum Fix
 {
-	no_fix, enhance_early, revenge_on_death, num_fixes
+    no_fix,
+    enhance_early,
+    revenge_on_death,
+    death_from_bge,
+    num_fixes
 };
 
 class Card;

--- a/tyrant_optimize.cpp
+++ b/tyrant_optimize.cpp
@@ -210,10 +210,11 @@ void init()
 
 	//fix defaults
 	for (int i=0; i < Fix::num_fixes;++i) fixes[i]=false;
-	//recommended/default fixes
+
+    //recommended/default fixes
 	fixes[Fix::enhance_early] = true;
 	fixes[Fix::revenge_on_death] = true;
-
+	fixes[Fix::death_from_bge] = true;
 }
 
 #if defined(ANDROID) || defined(__ANDROID__)
@@ -2094,6 +2095,10 @@ FinalResults<long double> run(int argc, char** argv)
 		else if (strcmp(argv[argIndex], "fix-revenge-on-death") == 0)
 		{
 			fixes[Fix::revenge_on_death] = true;
+		}
+		else if (strcmp(argv[argIndex], "fix-death-from-bge") == 0)
+		{
+			fixes[Fix::death_from_bge] = true;
 		}
 		else if (strcmp(argv[argIndex], "seed") == 0)
 		{


### PR DESCRIPTION
I noticed that when units die from an activation BGE skill (Strike for instance), any death depended triggers (On Death, skill Scavenge) does not work at all.

In first time I noticed such strange behaviour under BGE "Siege All 999", so, Scavenge was not triggering on ruined dominions, but that time I could not determine the root of the problem. Now we have "Enfeeble all 30 + Strike all 30" BGE, and when you play Inhanler against Vironak (Enfeeble from BGE + from On Play + Strike from BGE (but not from commander!)), Vironak dies and no any Mortar. And no Scavenge triggered. I guess Avenge too.